### PR TITLE
chore: make dumi types can be resolved

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,10 +15,9 @@
     "types": ["jest", "node"],
     "paths": {
       "@/*": ["src/*"],
-      "@@/*": ["src/.umi/*"],
+      "@@/*": [".dumi/tmp/*"],
       "rc-segmented": ["src/index.tsx"]
     }
   },
-  "include": ["src", "tests", "docs/examples"],
-  "exclude": [".umi*"]
+  "include": [".dumi/**/*", ".dumirc.ts", "src", "tests", "docs/examples"],
 }


### PR DESCRIPTION
修复 `.dumirc.ts` 里 `defineConfig` 类型缺失的问题