### PR TITLE
fix: end animation when element is hidden

### DIFF
--- a/src/MotionThumb.tsx
+++ b/src/MotionThumb.tsx
@@ -55,7 +55,7 @@ export default function MotionThumb(props: MotionThumbInterface) {
       `.${prefixCls}-item`,
     )[index];
 
-    return ele;
+    return ele?.offsetParent && ele;
   };
 
   const [prevStyle, setPrevStyle] = React.useState<ThumbReact>(null);


### PR DESCRIPTION
Fix: https://github.com/ant-design/ant-design/issues/40237

In this PR, MotionThumb is able to detect the hidden item wrapped into "Modal" during `forceRender` and `visible={false}` options. Then ignore them and trigger `onMotionEnd()` to place "selected" classname for segment item.
