### PR TITLE
fix: options' className overwriting default styles instead of extending them

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -197,6 +197,7 @@ const Segmented = React.forwardRef<HTMLDivElement, SegmentedProps>(
           />
           {segmentedOptions.map((segmentedOption) => (
             <InternalSegmentedOption
+              {...segmentedOption}
               key={segmentedOption.value}
               prefixCls={prefixCls}
               className={classNames(
@@ -209,7 +210,6 @@ const Segmented = React.forwardRef<HTMLDivElement, SegmentedProps>(
               )}
               checked={segmentedOption.value === rawValue}
               onChange={handleChange}
-              {...segmentedOption}
               disabled={!!disabled || !!segmentedOption.disabled}
             />
           ))}


### PR DESCRIPTION
Fixes #75 

Currently, options are being spread after `className`, causing any option defined with custom `className` to lose the default styles.