### PR TITLE
受控模式下不默认选中第一个

### DIFF
--- a/docs/demo/controlled.tsx
+++ b/docs/demo/controlled.tsx
@@ -5,10 +5,11 @@ import type { SegmentedValue } from 'rc-segmented';
 
 export default class Demo extends React.Component<
   unknown,
-  { value: SegmentedValue }
+  { value: SegmentedValue; value2?: SegmentedValue }
 > {
   state = {
     value: 'Web3',
+    value2: undefined,
   };
 
   render() {
@@ -23,13 +24,23 @@ export default class Demo extends React.Component<
             })
           }
         />
-        &nbsp;&nbsp;
+        &nbsp;
         <Segmented
           options={['iOS', 'Android', 'Web3']}
           value={this.state.value}
           onChange={(value) =>
             this.setState({
               value,
+            })
+          }
+        />
+        &nbsp;
+        <Segmented
+          options={['iOS', 'Android', 'Web3']}
+          value={this.state.value2}
+          onChange={(value2) =>
+            this.setState({
+              value2,
             })
           }
         />

--- a/src/MotionThumb.tsx
+++ b/src/MotionThumb.tsx
@@ -13,7 +13,7 @@ type ThumbReact = {
 
 export interface MotionThumbInterface {
   containerRef: React.RefObject<HTMLDivElement>;
-  value: SegmentedValue;
+  value?: SegmentedValue;
   getValueIndex: (value: SegmentedValue) => number;
   prefixCls: string;
   motionName: string;
@@ -55,7 +55,8 @@ export default function MotionThumb(props: MotionThumbInterface) {
   const [prevValue, setPrevValue] = React.useState(value);
 
   // =========================== Effect ===========================
-  const findValueElement = (val: SegmentedValue) => {
+  const findValueElement = (val?: SegmentedValue) => {
+    if (!val) return null;
     const index = getValueIndex(val);
 
     const ele = containerRef.current?.querySelectorAll<HTMLDivElement>(
@@ -90,16 +91,20 @@ export default function MotionThumb(props: MotionThumbInterface) {
 
   const thumbStart = React.useMemo(
     () =>
-      direction === 'rtl'
-        ? toPX(-(prevStyle?.right as number))
-        : toPX(prevStyle?.left as number),
+      prevStyle
+        ? direction === 'rtl'
+          ? toPX(-(prevStyle?.right as number))
+          : toPX(prevStyle?.left as number)
+        : 'auto',
     [direction, prevStyle],
   );
   const thumbActive = React.useMemo(
     () =>
-      direction === 'rtl'
-        ? toPX(-(nextStyle?.right as number))
-        : toPX(nextStyle?.left as number),
+      nextStyle
+        ? direction === 'rtl'
+          ? toPX(-(nextStyle?.right as number))
+          : toPX(nextStyle?.left as number)
+        : 'auto',
     [direction, nextStyle],
   );
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -142,10 +142,13 @@ const Segmented = React.forwardRef<HTMLDivElement, SegmentedProps>(
 
     // Note: We should not auto switch value when value not exist in options
     // which may break single source of truth.
-    const [rawValue, setRawValue] = useMergedState(segmentedOptions[0]?.value, {
-      value,
-      defaultValue,
-    });
+    const [rawValue, setRawValue] = useMergedState(
+      props.hasOwnProperty('value') ? value : segmentedOptions[0]?.value,
+      {
+        value,
+        defaultValue,
+      },
+    );
 
     // ======================= Change ========================
     const [thumbShow, setThumbShow] = React.useState(false);


### PR DESCRIPTION
当外部传入 `value` 时，即使为 `undefined`，也应该取 `value` 的值，而不是默认取配置项第一个，查看下面的示例：

https://stackblitz.com/edit/react-7an8od?file=demo.tsx

在 `antd` 的 `Form` 中，此行为会让用户误以为已经帮他选中了第一个，而 `Form` 中的其他组件没有此行为。