### PR TITLE
fix: add aria-hidden attribute to visually hidden input element

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -107,6 +107,7 @@ const InternalSegmentedOption: React.FC<{
     >
       <input
         className={`${prefixCls}-item-input`}
+        aria-hidden="true"
         type="radio"
         disabled={disabled}
         checked={checked}

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`rc-segmented render label with ReactNode 1`] = `
       class="rc-segmented-item rc-segmented-item-selected"
     >
       <input
+        aria-hidden="true"
         checked=""
         class="rc-segmented-item-input"
         type="radio"
@@ -42,6 +43,7 @@ exports[`rc-segmented render label with ReactNode 1`] = `
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />
@@ -61,6 +63,7 @@ exports[`rc-segmented render label with ReactNode 1`] = `
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />
@@ -91,6 +94,7 @@ exports[`rc-segmented render segmented ok 1`] = `
       class="rc-segmented-item rc-segmented-item-selected"
     >
       <input
+        aria-hidden="true"
         checked=""
         class="rc-segmented-item-input"
         type="radio"
@@ -108,6 +112,7 @@ exports[`rc-segmented render segmented ok 1`] = `
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />
@@ -124,6 +129,7 @@ exports[`rc-segmented render segmented ok 1`] = `
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />
@@ -153,6 +159,7 @@ exports[`rc-segmented render segmented with CSSMotion basic 1`] = `
       class="rc-segmented-item rc-segmented-item-selected"
     >
       <input
+        aria-hidden="true"
         checked=""
         class="rc-segmented-item-input"
         type="radio"
@@ -170,6 +177,7 @@ exports[`rc-segmented render segmented with CSSMotion basic 1`] = `
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />
@@ -186,6 +194,7 @@ exports[`rc-segmented render segmented with CSSMotion basic 1`] = `
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />
@@ -215,6 +224,7 @@ exports[`rc-segmented render segmented with options 1`] = `
       class="rc-segmented-item rc-segmented-item-selected"
     >
       <input
+        aria-hidden="true"
         checked=""
         class="rc-segmented-item-input"
         type="radio"
@@ -232,6 +242,7 @@ exports[`rc-segmented render segmented with options 1`] = `
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />
@@ -248,6 +259,7 @@ exports[`rc-segmented render segmented with options 1`] = `
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />
@@ -277,6 +289,7 @@ exports[`rc-segmented render segmented with options null/undefined 1`] = `
       class="rc-segmented-item rc-segmented-item-selected rc-segmented-item-disabled"
     >
       <input
+        aria-hidden="true"
         checked=""
         class="rc-segmented-item-input"
         disabled=""
@@ -292,6 +305,7 @@ exports[`rc-segmented render segmented with options null/undefined 1`] = `
       class="rc-segmented-item rc-segmented-item-disabled"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         disabled=""
         type="radio"
@@ -306,6 +320,7 @@ exports[`rc-segmented render segmented with options null/undefined 1`] = `
       class="rc-segmented-item rc-segmented-item-disabled"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         disabled=""
         type="radio"
@@ -334,6 +349,7 @@ exports[`rc-segmented render segmented with options: 1 1`] = `
       class="rc-segmented-item rc-segmented-item-selected"
     >
       <input
+        aria-hidden="true"
         checked=""
         class="rc-segmented-item-input"
         type="radio"
@@ -351,6 +367,7 @@ exports[`rc-segmented render segmented with options: 1 1`] = `
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />
@@ -367,6 +384,7 @@ exports[`rc-segmented render segmented with options: 1 1`] = `
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />
@@ -383,6 +401,7 @@ exports[`rc-segmented render segmented with options: 1 1`] = `
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />
@@ -399,6 +418,7 @@ exports[`rc-segmented render segmented with options: 1 1`] = `
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />
@@ -428,6 +448,7 @@ exports[`rc-segmented render segmented with options: 2 1`] = `
       class="rc-segmented-item rc-segmented-item-selected"
     >
       <input
+        aria-hidden="true"
         checked=""
         class="rc-segmented-item-input"
         type="radio"
@@ -445,6 +466,7 @@ exports[`rc-segmented render segmented with options: 2 1`] = `
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />
@@ -461,6 +483,7 @@ exports[`rc-segmented render segmented with options: 2 1`] = `
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />
@@ -490,6 +513,7 @@ exports[`rc-segmented render segmented with options: disabled 1`] = `
       class="rc-segmented-item rc-segmented-item-selected"
     >
       <input
+        aria-hidden="true"
         checked=""
         class="rc-segmented-item-input"
         type="radio"
@@ -507,6 +531,7 @@ exports[`rc-segmented render segmented with options: disabled 1`] = `
       class="rc-segmented-item rc-segmented-item-disabled"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         disabled=""
         type="radio"
@@ -524,6 +549,7 @@ exports[`rc-segmented render segmented with options: disabled 1`] = `
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />
@@ -553,6 +579,7 @@ exports[`rc-segmented render segmented with title 1`] = `
       class="rc-segmented-item rc-segmented-item-selected"
     >
       <input
+        aria-hidden="true"
         checked=""
         class="rc-segmented-item-input"
         type="radio"
@@ -570,6 +597,7 @@ exports[`rc-segmented render segmented with title 1`] = `
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />
@@ -586,6 +614,7 @@ exports[`rc-segmented render segmented with title 1`] = `
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />
@@ -603,6 +632,7 @@ exports[`rc-segmented render segmented with title 1`] = `
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />
@@ -619,6 +649,7 @@ exports[`rc-segmented render segmented with title 1`] = `
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />
@@ -648,6 +679,7 @@ exports[`rc-segmented render segmented: disabled 1`] = `
       class="rc-segmented-item rc-segmented-item-selected rc-segmented-item-disabled"
     >
       <input
+        aria-hidden="true"
         checked=""
         class="rc-segmented-item-input"
         disabled=""
@@ -666,6 +698,7 @@ exports[`rc-segmented render segmented: disabled 1`] = `
       class="rc-segmented-item rc-segmented-item-disabled"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         disabled=""
         type="radio"
@@ -683,6 +716,7 @@ exports[`rc-segmented render segmented: disabled 1`] = `
       class="rc-segmented-item rc-segmented-item-disabled"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         disabled=""
         type="radio"
@@ -713,6 +747,7 @@ exports[`rc-segmented should render vertical segmented 1`] = `
       class="rc-segmented-item rc-segmented-item-selected"
     >
       <input
+        aria-hidden="true"
         checked=""
         class="rc-segmented-item-input"
         type="radio"
@@ -730,6 +765,7 @@ exports[`rc-segmented should render vertical segmented 1`] = `
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />
@@ -746,6 +782,7 @@ exports[`rc-segmented should render vertical segmented 1`] = `
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />
@@ -775,6 +812,7 @@ exports[`rc-segmented should render vertical segmented and handle thumb animatio
       class="rc-segmented-item rc-segmented-item-selected"
     >
       <input
+        aria-hidden="true"
         checked=""
         class="rc-segmented-item-input"
         type="radio"
@@ -792,6 +830,7 @@ exports[`rc-segmented should render vertical segmented and handle thumb animatio
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />
@@ -808,6 +847,7 @@ exports[`rc-segmented should render vertical segmented and handle thumb animatio
       class="rc-segmented-item"
     >
       <input
+        aria-hidden="true"
         class="rc-segmented-item-input"
         type="radio"
       />


### PR DESCRIPTION
## Description
添加了 `aria-hidden="true"` 属性到视觉隐藏的 radio input 元素上，以优化屏幕阅读器的体验。

## 改动原因
该 radio input 元素仅用于组件内部状态管理，不需要被屏幕阅读器读取。添加 `aria-hidden` 属性可以防止冗余的朗读信息，提升无障碍体验。

## 相关改动
- 为 Segmented 组件中的隐藏 input 元素添加 `aria-hidden="true"` 属性

## 参考文档
- [WAI-ARIA: aria-hidden 属性](https://www.w3.org/WAI/ARIA/apg/attributes/aria-hidden/)
- [MDN: aria-hidden](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 在 `InternalSegmentedOption` 组件的 `<input>` 元素中添加了 `aria-hidden="true"` 属性，增强了可访问性，使辅助技术忽略该输入。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->