### PR TITLE
feat: support `name` prop to enable grouping

### DIFF
--- a/docs/demo/name.tsx
+++ b/docs/demo/name.tsx
@@ -1,0 +1,17 @@
+import Segmented from 'rc-segmented';
+import React from 'react';
+import '../../assets/style.less';
+
+export default function App() {
+  return (
+    <div>
+      <div className="wrapper">
+        <Segmented
+          name="group"
+          options={['iOS', 'Android', 'Web']}
+          onChange={(value) => console.log(value, typeof value)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/docs/example.md
+++ b/docs/example.md
@@ -32,3 +32,7 @@ nav:
 ## rtl
 
 <code src="./demo/rtl.tsx"></code>
+
+## name
+
+<code src="./demo/name.tsx"></code>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -40,6 +40,7 @@ export interface SegmentedProps<ValueType = SegmentedValue>
   direction?: 'ltr' | 'rtl';
   motionName?: string;
   vertical?: boolean;
+  name?: string;
 }
 
 function getValidTitle(option: SegmentedLabeledOption) {
@@ -78,6 +79,7 @@ const InternalSegmentedOption: React.FC<{
   label: React.ReactNode;
   title?: string;
   value: SegmentedRawOption;
+  name?: string;
   onChange: (
     e: React.ChangeEvent<HTMLInputElement>,
     value: SegmentedRawOption,
@@ -90,6 +92,7 @@ const InternalSegmentedOption: React.FC<{
   label,
   title,
   value,
+  name,
   onChange,
 }) => {
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -106,6 +109,7 @@ const InternalSegmentedOption: React.FC<{
       })}
     >
       <input
+        name={name}
         className={`${prefixCls}-item-input`}
         aria-hidden="true"
         type="radio"
@@ -135,6 +139,7 @@ const Segmented = React.forwardRef<HTMLDivElement, SegmentedProps>(
       disabled,
       defaultValue,
       value,
+      name,
       onChange,
       className = '',
       motionName = 'thumb-motion',
@@ -208,6 +213,7 @@ const Segmented = React.forwardRef<HTMLDivElement, SegmentedProps>(
           {segmentedOptions.map((segmentedOption) => (
             <InternalSegmentedOption
               {...segmentedOption}
+              name={name}
               key={segmentedOption.value}
               prefixCls={prefixCls}
               className={classNames(

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -650,4 +650,17 @@ describe('rc-segmented', () => {
 
     offsetParentSpy.mockRestore();
   });
+
+  it('all children should have a name property', () => {
+    const GROUP_NAME = 'GROUP_NAME';
+    const { container } = render(
+      <Segmented options={['iOS', 'Android', 'Web']} name={GROUP_NAME} />,
+    );
+
+    container
+      .querySelectorAll<HTMLInputElement>('input[type="radio"]')
+      .forEach((el) => {
+        expect(el.name).toEqual(GROUP_NAME);
+      });
+  });
 });


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/51698

![image](https://github.com/user-attachments/assets/9abd4264-0744-44d2-a5d0-711f978b024d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新功能**
	- 新增了 `App` 组件，包含分段选择功能，支持选择 'iOS'、'Android' 和 'Web' 选项。
	- `Segmented` 组件现在支持可选的 `name` 属性，以便对单选按钮进行分组。
	- 文档中新增了名为 "name" 的部分，引用了新组件的代码示例。
- **文档**
	- 更新了文档 `docs/example.md`，增加了新部分和代码引用。
- **测试**
	- 新增测试用例，验证 `Segmented` 组件生成的所有单选输入元素是否具有指定的 `name` 属性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->