### PR TITLE
chore: bump util & father plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "rc-segmented",
-  "version": "2.7.0",
+  "name": "@rc-component/segmented",
+  "version": "1.0.0-1",
   "description": "React segmented controls used in ant.design",
   "keywords": [
     "react",
@@ -49,7 +49,7 @@
     "@babel/runtime": "^7.11.1",
     "classnames": "^2.2.1",
     "rc-motion": "^2.4.4",
-    "rc-util": "^5.17.0"
+    "@rc-component/util": "^1.1.0"
   },
   "devDependencies": {
     "@rc-component/father-plugin": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@rc-component/util": "^1.1.0"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^1.0.1",
+    "@rc-component/father-plugin": "^2.0.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.2.1",
     "@testing-library/user-event": "^14.5.2",

--- a/src/MotionThumb.tsx
+++ b/src/MotionThumb.tsx
@@ -1,7 +1,7 @@
+import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
+import { composeRef } from '@rc-component/util/lib/ref';
 import classNames from 'classnames';
 import CSSMotion from 'rc-motion';
-import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect';
-import { composeRef } from 'rc-util/lib/ref';
 import * as React from 'react';
 import type { SegmentedValue } from '.';
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
+import useMergedState from '@rc-component/util/lib/hooks/useMergedState';
+import omit from '@rc-component/util/lib/omit';
+import { composeRef } from '@rc-component/util/lib/ref';
 import classNames from 'classnames';
-import useMergedState from 'rc-util/lib/hooks/useMergedState';
-import omit from 'rc-util/lib/omit';
-import { composeRef } from 'rc-util/lib/ref';
 import * as React from 'react';
 
 import MotionThumb from './MotionThumb';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **包管理**
	- 包名从 `rc-segmented` 更新为 `@rc-component/segmented`
	- 版本号重置为 `1.0.0-1`
	- 依赖包从 `rc-util` 更新为 `@rc-component/util`
	- 开发依赖 `@rc-component/father-plugin` 升级到 `2.0.1` 版本

- **代码依赖**
	- 更新了内部实用函数的导入路径
	- 未改变组件的核心功能和逻辑

<!-- end of auto-generated comment: release notes by coderabbit.ai -->