### PR TITLE
feat: improved accessibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@rc-component/father-plugin": "^2.0.1",
+    "@rc-component/np": "^1.0.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.2.1",
     "@testing-library/user-event": "^14.5.2",
@@ -73,7 +74,6 @@
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
     "less": "^3.10.3",
-    "np": "^7.0.0",
     "prettier": "^2.0.5",
     "pretty-quick": "^3.0.0",
     "react": "^18.0.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -147,8 +147,8 @@ const InternalSegmentedOption: React.FC<{
           segmentedClassNames?.label,
         )}
         title={title}
-        role="option"
-        aria-selected={checked}
+        role="radio"
+        aria-checked={checked}
         style={styles?.label}
       >
         {label}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -147,6 +147,7 @@ const InternalSegmentedOption: React.FC<{
           segmentedClassNames?.label,
         )}
         title={title}
+        role="option"
         aria-selected={checked}
         style={styles?.label}
       >

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -32,9 +32,9 @@ exports[`rc-segmented render label with ReactNode 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
+        aria-checked="true"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="iOS"
       >
         iOS
@@ -48,9 +48,9 @@ exports[`rc-segmented render label with ReactNode 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
       >
         <div
           id="android"
@@ -67,9 +67,9 @@ exports[`rc-segmented render label with ReactNode 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
       >
         <h2>
           Web
@@ -99,9 +99,9 @@ exports[`rc-segmented render segmented ok 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
+        aria-checked="true"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="iOS"
       >
         iOS
@@ -115,9 +115,9 @@ exports[`rc-segmented render segmented ok 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="Android"
       >
         Android
@@ -131,9 +131,9 @@ exports[`rc-segmented render segmented ok 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="Web"
       >
         Web
@@ -162,9 +162,9 @@ exports[`rc-segmented render segmented with CSSMotion basic 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
+        aria-checked="true"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="iOS"
       >
         iOS
@@ -178,9 +178,9 @@ exports[`rc-segmented render segmented with CSSMotion basic 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="Android"
       >
         Android
@@ -194,9 +194,9 @@ exports[`rc-segmented render segmented with CSSMotion basic 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="Web3"
       >
         Web3
@@ -225,9 +225,9 @@ exports[`rc-segmented render segmented with options 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
+        aria-checked="true"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="iOS"
       >
         iOS
@@ -241,9 +241,9 @@ exports[`rc-segmented render segmented with options 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="Android"
       >
         Android
@@ -257,9 +257,9 @@ exports[`rc-segmented render segmented with options 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="Web"
       >
         Web
@@ -288,9 +288,9 @@ exports[`rc-segmented render segmented with options null/undefined 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
+        aria-checked="true"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
       />
     </label>
     <label
@@ -302,9 +302,9 @@ exports[`rc-segmented render segmented with options null/undefined 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
       />
     </label>
     <label
@@ -316,9 +316,9 @@ exports[`rc-segmented render segmented with options null/undefined 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title=""
       />
     </label>
@@ -345,9 +345,9 @@ exports[`rc-segmented render segmented with options: 1 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
+        aria-checked="true"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="1"
       >
         1
@@ -361,9 +361,9 @@ exports[`rc-segmented render segmented with options: 1 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="2"
       >
         2
@@ -377,9 +377,9 @@ exports[`rc-segmented render segmented with options: 1 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="3"
       >
         3
@@ -393,9 +393,9 @@ exports[`rc-segmented render segmented with options: 1 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="4"
       >
         4
@@ -409,9 +409,9 @@ exports[`rc-segmented render segmented with options: 1 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="5"
       >
         5
@@ -440,9 +440,9 @@ exports[`rc-segmented render segmented with options: 2 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
+        aria-checked="true"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="iOS"
       >
         iOS
@@ -456,9 +456,9 @@ exports[`rc-segmented render segmented with options: 2 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="Android"
       >
         Android
@@ -472,9 +472,9 @@ exports[`rc-segmented render segmented with options: 2 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="Web"
       >
         Web
@@ -503,9 +503,9 @@ exports[`rc-segmented render segmented with options: disabled 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
+        aria-checked="true"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="iOS"
       >
         iOS
@@ -520,9 +520,9 @@ exports[`rc-segmented render segmented with options: disabled 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="Android"
       >
         Android
@@ -536,9 +536,9 @@ exports[`rc-segmented render segmented with options: disabled 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="Web"
       >
         Web
@@ -567,9 +567,9 @@ exports[`rc-segmented render segmented with title 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
+        aria-checked="true"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="Web"
       >
         Web
@@ -583,9 +583,9 @@ exports[`rc-segmented render segmented with title 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="hello1"
       >
         hello1
@@ -599,9 +599,9 @@ exports[`rc-segmented render segmented with title 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
       >
         <div>
           test1
@@ -616,9 +616,9 @@ exports[`rc-segmented render segmented with title 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="hello1.5"
       >
         hello1
@@ -632,9 +632,9 @@ exports[`rc-segmented render segmented with title 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title=""
       >
         foo1
@@ -663,9 +663,9 @@ exports[`rc-segmented render segmented: disabled 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
+        aria-checked="true"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="iOS"
       >
         iOS
@@ -680,9 +680,9 @@ exports[`rc-segmented render segmented: disabled 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="Android"
       >
         Android
@@ -697,9 +697,9 @@ exports[`rc-segmented render segmented: disabled 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="Web"
       >
         Web
@@ -728,9 +728,9 @@ exports[`rc-segmented should render vertical segmented 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
+        aria-checked="true"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="iOS"
       >
         iOS
@@ -744,9 +744,9 @@ exports[`rc-segmented should render vertical segmented 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="Android"
       >
         Android
@@ -760,9 +760,9 @@ exports[`rc-segmented should render vertical segmented 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="Web"
       >
         Web
@@ -791,9 +791,9 @@ exports[`rc-segmented should render vertical segmented and handle thumb animatio
         type="radio"
       />
       <div
-        aria-selected="true"
+        aria-checked="true"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="iOS"
       >
         iOS
@@ -807,9 +807,9 @@ exports[`rc-segmented should render vertical segmented and handle thumb animatio
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="Android"
       >
         Android
@@ -823,9 +823,9 @@ exports[`rc-segmented should render vertical segmented and handle thumb animatio
         type="radio"
       />
       <div
-        aria-selected="false"
+        aria-checked="false"
         class="rc-segmented-item-label"
-        role="option"
+        role="radio"
         title="Web"
       >
         Web

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -34,6 +34,7 @@ exports[`rc-segmented render label with ReactNode 1`] = `
       <div
         aria-selected="true"
         class="rc-segmented-item-label"
+        role="option"
         title="iOS"
       >
         iOS
@@ -49,6 +50,7 @@ exports[`rc-segmented render label with ReactNode 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
       >
         <div
           id="android"
@@ -67,6 +69,7 @@ exports[`rc-segmented render label with ReactNode 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
       >
         <h2>
           Web
@@ -98,6 +101,7 @@ exports[`rc-segmented render segmented ok 1`] = `
       <div
         aria-selected="true"
         class="rc-segmented-item-label"
+        role="option"
         title="iOS"
       >
         iOS
@@ -113,6 +117,7 @@ exports[`rc-segmented render segmented ok 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title="Android"
       >
         Android
@@ -128,6 +133,7 @@ exports[`rc-segmented render segmented ok 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title="Web"
       >
         Web
@@ -158,6 +164,7 @@ exports[`rc-segmented render segmented with CSSMotion basic 1`] = `
       <div
         aria-selected="true"
         class="rc-segmented-item-label"
+        role="option"
         title="iOS"
       >
         iOS
@@ -173,6 +180,7 @@ exports[`rc-segmented render segmented with CSSMotion basic 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title="Android"
       >
         Android
@@ -188,6 +196,7 @@ exports[`rc-segmented render segmented with CSSMotion basic 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title="Web3"
       >
         Web3
@@ -218,6 +227,7 @@ exports[`rc-segmented render segmented with options 1`] = `
       <div
         aria-selected="true"
         class="rc-segmented-item-label"
+        role="option"
         title="iOS"
       >
         iOS
@@ -233,6 +243,7 @@ exports[`rc-segmented render segmented with options 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title="Android"
       >
         Android
@@ -248,6 +259,7 @@ exports[`rc-segmented render segmented with options 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title="Web"
       >
         Web
@@ -278,6 +290,7 @@ exports[`rc-segmented render segmented with options null/undefined 1`] = `
       <div
         aria-selected="true"
         class="rc-segmented-item-label"
+        role="option"
       />
     </label>
     <label
@@ -291,6 +304,7 @@ exports[`rc-segmented render segmented with options null/undefined 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
       />
     </label>
     <label
@@ -304,6 +318,7 @@ exports[`rc-segmented render segmented with options null/undefined 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title=""
       />
     </label>
@@ -332,6 +347,7 @@ exports[`rc-segmented render segmented with options: 1 1`] = `
       <div
         aria-selected="true"
         class="rc-segmented-item-label"
+        role="option"
         title="1"
       >
         1
@@ -347,6 +363,7 @@ exports[`rc-segmented render segmented with options: 1 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title="2"
       >
         2
@@ -362,6 +379,7 @@ exports[`rc-segmented render segmented with options: 1 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title="3"
       >
         3
@@ -377,6 +395,7 @@ exports[`rc-segmented render segmented with options: 1 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title="4"
       >
         4
@@ -392,6 +411,7 @@ exports[`rc-segmented render segmented with options: 1 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title="5"
       >
         5
@@ -422,6 +442,7 @@ exports[`rc-segmented render segmented with options: 2 1`] = `
       <div
         aria-selected="true"
         class="rc-segmented-item-label"
+        role="option"
         title="iOS"
       >
         iOS
@@ -437,6 +458,7 @@ exports[`rc-segmented render segmented with options: 2 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title="Android"
       >
         Android
@@ -452,6 +474,7 @@ exports[`rc-segmented render segmented with options: 2 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title="Web"
       >
         Web
@@ -482,6 +505,7 @@ exports[`rc-segmented render segmented with options: disabled 1`] = `
       <div
         aria-selected="true"
         class="rc-segmented-item-label"
+        role="option"
         title="iOS"
       >
         iOS
@@ -498,6 +522,7 @@ exports[`rc-segmented render segmented with options: disabled 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title="Android"
       >
         Android
@@ -513,6 +538,7 @@ exports[`rc-segmented render segmented with options: disabled 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title="Web"
       >
         Web
@@ -543,6 +569,7 @@ exports[`rc-segmented render segmented with title 1`] = `
       <div
         aria-selected="true"
         class="rc-segmented-item-label"
+        role="option"
         title="Web"
       >
         Web
@@ -558,6 +585,7 @@ exports[`rc-segmented render segmented with title 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title="hello1"
       >
         hello1
@@ -573,6 +601,7 @@ exports[`rc-segmented render segmented with title 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
       >
         <div>
           test1
@@ -589,6 +618,7 @@ exports[`rc-segmented render segmented with title 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title="hello1.5"
       >
         hello1
@@ -604,6 +634,7 @@ exports[`rc-segmented render segmented with title 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title=""
       >
         foo1
@@ -634,6 +665,7 @@ exports[`rc-segmented render segmented: disabled 1`] = `
       <div
         aria-selected="true"
         class="rc-segmented-item-label"
+        role="option"
         title="iOS"
       >
         iOS
@@ -650,6 +682,7 @@ exports[`rc-segmented render segmented: disabled 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title="Android"
       >
         Android
@@ -666,6 +699,7 @@ exports[`rc-segmented render segmented: disabled 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title="Web"
       >
         Web
@@ -696,6 +730,7 @@ exports[`rc-segmented should render vertical segmented 1`] = `
       <div
         aria-selected="true"
         class="rc-segmented-item-label"
+        role="option"
         title="iOS"
       >
         iOS
@@ -711,6 +746,7 @@ exports[`rc-segmented should render vertical segmented 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title="Android"
       >
         Android
@@ -726,6 +762,7 @@ exports[`rc-segmented should render vertical segmented 1`] = `
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title="Web"
       >
         Web
@@ -756,6 +793,7 @@ exports[`rc-segmented should render vertical segmented and handle thumb animatio
       <div
         aria-selected="true"
         class="rc-segmented-item-label"
+        role="option"
         title="iOS"
       >
         iOS
@@ -771,6 +809,7 @@ exports[`rc-segmented should render vertical segmented and handle thumb animatio
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title="Android"
       >
         Android
@@ -786,6 +825,7 @@ exports[`rc-segmented should render vertical segmented and handle thumb animatio
       <div
         aria-selected="false"
         class="rc-segmented-item-label"
+        role="option"
         title="Web"
       >
         Web


### PR DESCRIPTION
![QQ_1737462580657](https://github.com/user-attachments/assets/9334628b-ce0c-4daf-9a92-e0b6248878d0)

div不能设置aria-selected属性，而且segmented本质上还是个Radio，应该使用aria-checked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **辅助功能改进**
    - 更新分段选项组件的无障碍属性，将 `div` 元素的角色从通用选择指示器调整为更具语义的单选按钮角色。
    - 添加 `role="radio"` 和 `aria-checked` 属性，以提高组件的可访问性和屏幕阅读器兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->