### PR TITLE
fix: prevent selecting disabled items with keyboard navigation

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -237,15 +237,20 @@ const Segmented = React.forwardRef<HTMLDivElement, SegmentedProps>(
 
     // ======================= Keyboard ========================
     const onOffset = (offset: number) => {
-      const currentIndex = segmentedOptions.findIndex(
+      // keep the current option and not disabled options
+      const validOptions = segmentedOptions.filter(
+        (option) => option.value === rawValue || !option.disabled,
+      );
+
+      const currentIndex = validOptions.findIndex(
         (option) => option.value === rawValue,
       );
 
-      const total = segmentedOptions.length;
+      const total = validOptions.length;
       const nextIndex = (currentIndex + offset + total) % total;
+      const nextOption = validOptions[nextIndex];
 
-      const nextOption = segmentedOptions[nextIndex];
-      if (nextOption) {
+      if (nextOption && nextOption.value !== rawValue) {
         setRawValue(nextOption.value);
         onChange?.(nextOption.value);
       }

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -754,6 +754,33 @@ describe('Segmented keyboard navigation', () => {
     expect(onChange).toHaveBeenCalledWith('iOS');
   });
 
+  it('should not select a disabled option when it is the only next item', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const { container } = render(
+      <Segmented
+        options={[
+          { label: 'Enabled', value: 'enabled' },
+          { label: 'Disabled', value: 'disabled', disabled: true },
+        ]}
+        defaultValue="enabled"
+        onChange={onChange}
+      />,
+    );
+
+    await user.tab();
+    await user.tab();
+    await user.keyboard('{ArrowRight}');
+
+    const inputs = container.querySelectorAll<HTMLInputElement>(
+      '.rc-segmented-item-input',
+    );
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(inputs[0].checked).toBe(true);
+    expect(inputs[1].checked).toBe(false);
+  });
+
   it('should not have focus style when clicking', async () => {
     const user = userEvent.setup();
     const { container } = render(


### PR DESCRIPTION
## 背景

修复 ant-design/ant-design#57567 提到的问题：当 `Segmented` 通过键盘方向键切换选项时，不应选中 disabled item。

## 变更说明

- 在键盘切换时过滤掉 disabled 选项
- 保留当前选中项，避免在仅剩当前项和 disabled 项时发生错误切换
- 补充对应测试用例，覆盖只有下一个选项为 disabled 的场景

## 关联缺陷

fix https://github.com/ant-design/ant-design/issues/57567

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 优化键盘导航逻辑，在使用方向键导航时会自动跳过禁用选项，确保仅能选择启用的选项。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->