### PR TITLE
Avoid rc package deep imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,12 +47,12 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.11.1",
-    "@rc-component/util": "^1.3.0",
+    "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1",
     "@rc-component/motion": "^1.1.4"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.1",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^14.2.1",

--- a/src/MotionThumb.tsx
+++ b/src/MotionThumb.tsx
@@ -1,6 +1,5 @@
 import CSSMotion from '@rc-component/motion';
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
-import { composeRef } from '@rc-component/util/lib/ref';
+import { composeRef, useLayoutEffect } from '@rc-component/util';
 import { clsx } from 'clsx';
 import * as React from 'react';
 import type { SegmentedValue } from '.';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,4 @@
-import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
-import omit from '@rc-component/util/lib/omit';
-import { composeRef } from '@rc-component/util/lib/ref';
+import { composeRef, omit, useControlledState } from '@rc-component/util';
 import { clsx } from 'clsx';
 import * as React from 'react';
 


### PR DESCRIPTION
## 背景

antd 侧限制继续使用 rc 包的 `lib` / `es` 深路径导入，需要将 segmented 中对 rc 包内部路径的依赖迁移到包根入口。

## 调整内容

- 升级 `@rc-component/father-plugin`，使用插件统一拦截 rc 包 `lib` / `es` 深路径导入。
- 升级 `@rc-component/util`。
- 将源码中 `useLayoutEffect`、`composeRef`、`useControlledState`、`omit` 等内部路径引用改为从 `@rc-component/util` 根入口导入。
- 未扩大调整测试中的既有 mock 逻辑。

## 验证

- `npm run lint`
- `npm run type:check`
- `npm test -- --runInBand`
- `npm run compile`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* 升级核心依赖 `@rc-component/util` 版本至 ^1.11.1
* 升级开发依赖 `@rc-component/father-plugin` 版本至 ^2.2.0
* 优化内部模块导入结构

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/segmented/pull/327?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->