### PR TITLE
fix: avoid redundant radiogroup tab stop

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -308,7 +308,6 @@ const Segmented = React.forwardRef<HTMLDivElement, SegmentedProps>(
       <div
         role="radiogroup"
         aria-label="segmented control"
-        tabIndex={disabled ? undefined : 0}
         aria-orientation={vertical ? 'vertical' : 'horizontal'}
         style={style}
         {...divProps}

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -6,7 +6,6 @@ exports[`rc-segmented render empty segmented 1`] = `
   aria-orientation="horizontal"
   class="rc-segmented"
   role="radiogroup"
-  tabindex="0"
 >
   <div
     class="rc-segmented-group"
@@ -20,7 +19,6 @@ exports[`rc-segmented render label with ReactNode 1`] = `
   aria-orientation="horizontal"
   class="rc-segmented"
   role="radiogroup"
-  tabindex="0"
 >
   <div
     class="rc-segmented-group"
@@ -82,7 +80,6 @@ exports[`rc-segmented render segmented ok 1`] = `
   aria-orientation="horizontal"
   class="rc-segmented"
   role="radiogroup"
-  tabindex="0"
 >
   <div
     class="rc-segmented-group"
@@ -140,7 +137,6 @@ exports[`rc-segmented render segmented with CSSMotion basic 1`] = `
   aria-orientation="horizontal"
   class="rc-segmented"
   role="radiogroup"
-  tabindex="0"
 >
   <div
     class="rc-segmented-group"
@@ -198,7 +194,6 @@ exports[`rc-segmented render segmented with options 1`] = `
   aria-orientation="horizontal"
   class="rc-segmented"
   role="radiogroup"
-  tabindex="0"
 >
   <div
     class="rc-segmented-group"
@@ -308,7 +303,6 @@ exports[`rc-segmented render segmented with options: 1 1`] = `
   aria-orientation="horizontal"
   class="rc-segmented"
   role="radiogroup"
-  tabindex="0"
 >
   <div
     class="rc-segmented-group"
@@ -394,7 +388,6 @@ exports[`rc-segmented render segmented with options: 2 1`] = `
   aria-orientation="horizontal"
   class="rc-segmented"
   role="radiogroup"
-  tabindex="0"
 >
   <div
     class="rc-segmented-group"
@@ -452,7 +445,6 @@ exports[`rc-segmented render segmented with options: disabled 1`] = `
   aria-orientation="horizontal"
   class="rc-segmented"
   role="radiogroup"
-  tabindex="0"
 >
   <div
     class="rc-segmented-group"
@@ -511,7 +503,6 @@ exports[`rc-segmented render segmented with title 1`] = `
   aria-orientation="horizontal"
   class="rc-segmented"
   role="radiogroup"
-  tabindex="0"
 >
   <div
     class="rc-segmented-group"
@@ -658,7 +649,6 @@ exports[`rc-segmented should render vertical segmented 1`] = `
   aria-orientation="vertical"
   class="rc-segmented rc-segmented-vertical"
   role="radiogroup"
-  tabindex="0"
 >
   <div
     class="rc-segmented-group"
@@ -716,7 +706,6 @@ exports[`rc-segmented should render vertical segmented and handle thumb animatio
   aria-orientation="vertical"
   class="rc-segmented rc-segmented-vertical"
   role="radiogroup"
-  tabindex="0"
 >
   <div
     class="rc-segmented-group"

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -687,11 +687,17 @@ describe('Segmented keyboard navigation', () => {
     const firstInput = inputs[0];
 
     await user.tab();
-    // segmented container should be focused
-    expect(segmentedContainer).toHaveFocus();
-    await user.tab();
-    // first segmented item should be focused
+    // The radio group should not add an empty stop before its native radios.
+    expect(segmentedContainer).not.toHaveAttribute('tabindex');
     expect(firstInput).toHaveFocus();
+  });
+
+  it('should honor an explicit group tabIndex', () => {
+    const { getByRole } = render(
+      <Segmented options={['Daily', 'Weekly', 'Monthly']} tabIndex={0} />,
+    );
+
+    expect(getByRole('radiogroup')).toHaveAttribute('tabindex', '0');
   });
 
   it('should handle circular navigation with arrow keys', async () => {
@@ -701,8 +707,6 @@ describe('Segmented keyboard navigation', () => {
       <Segmented options={['iOS', 'Android', 'Web']} onChange={onChange} />,
     );
 
-    // focus on segmented
-    await user.tab();
     // focus on first item
     await user.tab();
 
@@ -752,7 +756,6 @@ describe('Segmented keyboard navigation', () => {
     );
 
     await user.tab();
-    await user.tab();
 
     await user.keyboard('{ArrowRight}');
     expect(onChange).toHaveBeenCalledWith('Web');
@@ -777,7 +780,6 @@ describe('Segmented keyboard navigation', () => {
       />,
     );
 
-    await user.tab();
     await user.tab();
     await user.keyboard('{ArrowRight}');
 


### PR DESCRIPTION
## Summary

- remove the default `tabIndex=0` from the outer radiogroup
- let the selected native radio receive the first Tab stop directly
- preserve an explicit consumer-provided `tabIndex` override
- update keyboard navigation coverage and snapshots

## Why

Segmented already renders native radio inputs and handles Arrow keys on those inputs. The outer `radiogroup` was also focusable by default, so keyboard users had to Tab twice: first onto a group node where Arrow keys do nothing, then onto the checked radio where the interaction actually works.

This aligns the focus path with the WAI-ARIA radio-group pattern: Tab enters the group on a checked radio (or the first radio when none is checked), and Arrow keys move within the group.

The exact-base regression fails because the first Tab focuses `radiogroup[tabindex="0"]` instead of the checked native radio.

Reference: https://www.w3.org/WAI/ARIA/apg/patterns/radio/

## Compatibility

`SegmentedProps` still accepts the inherited HTML `tabIndex` prop. Because the remaining `...divProps` spread applies it to the outer group, consumers that intentionally need a focusable group can continue to opt in; the added test covers that path.

## Validation

- `npm test -- --runInBand` (33 tests, 13 snapshots)
- `npm run tsc`
- `npm run lint` (no errors; one pre-existing `MotionThumb.tsx` exhaustive-deps warning)
- `npx prettier --check src/index.tsx tests/index.test.tsx`
- `npm run compile`
- `git diff --check`

## Overlap audit

No currently open rc-segmented PR changes `src/index.tsx` or its keyboard tests.

AI assistance disclosure: Codex was used to trace the focus path, audit open PR files and history, and draft the regression. The exact-base failure and fixed validation were run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化 Segmented 控件的键盘导航体验：按一次 Tab 键即可聚焦首个单选项。
  * 默认情况下不再为控件容器设置 `tabindex`，避免产生额外的焦点停留。
  * 显式设置焦点顺序时，仍支持为单选组容器设置 `tabindex="0"`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->